### PR TITLE
include parent property alias in data element attribute

### DIFF
--- a/src/ConditionalDisplayers/App_Plugins/ConditionalDisplayers/propertyeditors/checkbox/checkbox.controller.js
+++ b/src/ConditionalDisplayers/App_Plugins/ConditionalDisplayers/propertyeditors/checkbox/checkbox.controller.js
@@ -1,7 +1,9 @@
-﻿angular.module("umbraco").controller("Our.Umbraco.ConditionalDisplayers.CheckboxController", cdCheckboxController)
+﻿angular.module("umbraco").controller("Our.Umbraco.ConditionalDisplayers.CheckboxController", cdCheckboxController);
 
 
 function cdCheckboxController($scope) {
+
+    var parentPropertyAlias = $scope.model.alias.toString().replace($scope.model.propertyAlias, '');
 
     //the properties with alias in 'show' and 'hide' will be affected when the value is triggered.
     function displayProps(show, hide) {
@@ -32,7 +34,7 @@ function cdCheckboxController($scope) {
             if (h !== "") {
                 h += ",";
             }
-            h += "div[data-element='property-" + els[i].trim() + "']";
+            h += "div[data-element='property-" + parentPropertyAlias + els[i].trim() + "']";
         }
 
         return h;
@@ -46,7 +48,7 @@ function cdCheckboxController($scope) {
 
     $scope.clicked = function () {
         $scope.renderModel.value = !$scope.renderModel.value;
-    }
+    };
 
     $scope.runDisplayLogic = function () {
         //init visible fields
@@ -55,7 +57,7 @@ function cdCheckboxController($scope) {
         } else {
             displayProps($scope.model.config.showIfUnchecked, $scope.model.config.showIfChecked);
         }
-    }
+    };
 
     function setupViewModel() {
         $scope.renderModel = {
@@ -84,4 +86,4 @@ function cdCheckboxController($scope) {
 
     setupViewModel();
 
-};
+}

--- a/src/ConditionalDisplayers/App_Plugins/ConditionalDisplayers/propertyeditors/checkbox/checkbox.controller.js
+++ b/src/ConditionalDisplayers/App_Plugins/ConditionalDisplayers/propertyeditors/checkbox/checkbox.controller.js
@@ -34,7 +34,14 @@ function cdCheckboxController($scope) {
             if (h !== "") {
                 h += ",";
             }
-            h += "div[data-element='property-" + parentPropertyAlias + els[i].trim() + "']";
+
+            let prop = "div[data-element='property-" + parentPropertyAlias + els[i].trim() + "']";
+
+            if (!$(prop).length) {
+                prop = "div[data-element='property-" + els[i].trim() + "']";
+            }
+
+            h += prop;           
         }
 
         return h;

--- a/src/ConditionalDisplayers/App_Plugins/ConditionalDisplayers/propertyeditors/dropdownFlexible/dropdownFlexible.controller.js
+++ b/src/ConditionalDisplayers/App_Plugins/ConditionalDisplayers/propertyeditors/dropdownFlexible/dropdownFlexible.controller.js
@@ -1,5 +1,6 @@
 angular.module("umbraco").controller("Our.Umbraco.ConditionalDisplayers.DropdownController",
     function ($scope) {
+        var parentPropertyAlias = $scope.model.alias.toString().replace($scope.model.propertyAlias, '');
 
         //setup the default config
         var config = {
@@ -45,7 +46,7 @@ angular.module("umbraco").controller("Our.Umbraco.ConditionalDisplayers.Dropdown
             if (item) {
                 displayProps(item.show, item.hide);
             }
-        }
+        };
 
         if (angular.isArray($scope.model.config.items)) {
             //PP: I dont think this will happen, but we have tests that expect it to happen..
@@ -107,7 +108,7 @@ angular.module("umbraco").controller("Our.Umbraco.ConditionalDisplayers.Dropdown
                 if (h !== "") {
                     h += ",";
                 }
-                h += "div[data-element='property-" + els[i].trim() + "']";
+                h += "div[data-element='property-" + parentPropertyAlias + els[i].trim() + "']";
             }
 
             return h;

--- a/src/ConditionalDisplayers/App_Plugins/ConditionalDisplayers/propertyeditors/dropdownFlexible/dropdownFlexible.controller.js
+++ b/src/ConditionalDisplayers/App_Plugins/ConditionalDisplayers/propertyeditors/dropdownFlexible/dropdownFlexible.controller.js
@@ -108,7 +108,14 @@ angular.module("umbraco").controller("Our.Umbraco.ConditionalDisplayers.Dropdown
                 if (h !== "") {
                     h += ",";
                 }
-                h += "div[data-element='property-" + parentPropertyAlias + els[i].trim() + "']";
+         
+                let prop = "div[data-element='property-" + parentPropertyAlias + els[i].trim() + "']";
+
+                if (!$(prop).length) {
+                    prop = "div[data-element='property-" + els[i].trim() + "']";
+                }
+
+                h += prop;     
             }
 
             return h;


### PR DESCRIPTION
I've added the parent property alias as part of the value for data element attribute so that it can properly locate the DOM element, This is the fixed I've made for my project using Umbraco v7.15.3.

![image](https://user-images.githubusercontent.com/25155738/67631198-d9594080-f8cd-11e9-9eab-00c0562babe6.png)

![image](https://user-images.githubusercontent.com/25155738/67631202-e8d88980-f8cd-11e9-9b98-5edda7bbc395.png)
