### PR TITLE
Fix for Checkbox ConditionalDisplayer in u8.7

### DIFF
--- a/src/ConditionalDisplayers/App_Plugins/ConditionalDisplayers/propertyeditors/checkbox/checkbox.controller.js
+++ b/src/ConditionalDisplayers/App_Plugins/ConditionalDisplayers/propertyeditors/checkbox/checkbox.controller.js
@@ -20,11 +20,13 @@ function cdCheckboxController($scope, cdSharedLogic) {
     };
 
     $scope.runDisplayLogic = function () {
-        //init visible fields
-        if ($scope.renderModel.value) {
-            cdSharedLogic.displayProps($scope.model.config.showIfChecked, $scope.model.config.showIfUnchecked, parentPropertyAlias);
-        } else {
-            cdSharedLogic.displayProps($scope.model.config.showIfUnchecked, $scope.model.config.showIfChecked, parentPropertyAlias);
+        if (editorState.current.ModelState) {
+            //init visible fields
+            if ($scope.renderModel.value) {
+                cdSharedLogic.displayProps($scope.model.config.showIfChecked, $scope.model.config.showIfUnchecked, parentPropertyAlias);
+            } else {
+                cdSharedLogic.displayProps($scope.model.config.showIfUnchecked, $scope.model.config.showIfChecked, parentPropertyAlias);
+            }
         }
     };
 


### PR DESCRIPTION
Fixes properties being hidden in the DocumentType designer

This resolves issue #16 